### PR TITLE
Add double edge weight support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(CCACHE_PROGRAM)
 endif()
 project(KaHIP C CXX)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -166,6 +166,9 @@ set(LIBKAFFPA_SOURCE_FILES
   tools/tools.cpp)
 add_library(libkaffpa OBJECT ${LIBKAFFPA_SOURCE_FILES})
 
+# Double-weight variant of libkaffpa
+add_library(libkaffpa_double OBJECT ${LIBKAFFPA_SOURCE_FILES})
+target_compile_definitions(libkaffpa_double PRIVATE "EDGE_WEIGHT_DOUBLE")
 
 set(LIBCLUSTERING_SOURCE_FILES
   extern/argtable3-3.0.3/argtable3.c
@@ -190,6 +193,10 @@ set(LIBCLUSTERING_SOURCE_FILES
   tools/tools.cpp)
 add_library(libclustering OBJECT ${LIBCLUSTERING_SOURCE_FILES})
 
+# Double-weight variant of libclustering
+add_library(libclustering_double OBJECT ${LIBCLUSTERING_SOURCE_FILES})
+target_compile_definitions(libclustering_double PRIVATE "EDGE_WEIGHT_DOUBLE")
+
 set(LIBCLUSTERING_EVOLUTIONARY_SOURCE_FILES
   lib/algorithms/cycle_search.cpp
   lib/algorithms/strongly_connected_components.cpp
@@ -201,26 +208,58 @@ set(LIBCLUSTERING_EVOLUTIONARY_SOURCE_FILES
 add_library(libclustering_evolutionary OBJECT ${LIBCLUSTERING_EVOLUTIONARY_SOURCE_FILES})
 target_include_directories(libclustering_evolutionary PUBLIC ${MPI_CXX_INCLUDE_PATH})
 
-add_executable(scc_evaluator app/evaluator.cpp $<TARGET_OBJECTS:libkaffpa> )
-target_compile_definitions(scc_evaluator PRIVATE "-DMODE_EVALUATOR")
-target_link_libraries(scc_evaluator ${OpenMP_CXX_LIBRARIES})
-install(TARGETS scc_evaluator DESTINATION bin)
+# Double-weight variant of libclustering_evolutionary
+add_library(libclustering_evolutionary_double OBJECT ${LIBCLUSTERING_EVOLUTIONARY_SOURCE_FILES})
+target_compile_definitions(libclustering_evolutionary_double PRIVATE "EDGE_WEIGHT_DOUBLE")
+target_include_directories(libclustering_evolutionary_double PUBLIC ${MPI_CXX_INCLUDE_PATH})
 
-add_executable(scc_graphchecker app/graphchecker.cpp $<TARGET_OBJECTS:libkaffpa> )
-target_compile_definitions(scc_graphchecker PRIVATE "-DMODE_GRAPHCHECKER")
-target_link_libraries(scc_graphchecker ${OpenMP_CXX_LIBRARIES})
-install(TARGETS scc_graphchecker DESTINATION bin)
+# ===================== Int executables =====================
+add_executable(scc_evaluator_int app/evaluator.cpp $<TARGET_OBJECTS:libkaffpa>)
+target_compile_definitions(scc_evaluator_int PRIVATE "-DMODE_EVALUATOR")
+target_link_libraries(scc_evaluator_int ${OpenMP_CXX_LIBRARIES})
 
+add_executable(scc_graphchecker_int app/graphchecker.cpp $<TARGET_OBJECTS:libkaffpa>)
+target_compile_definitions(scc_graphchecker_int PRIVATE "-DMODE_GRAPHCHECKER")
+target_link_libraries(scc_graphchecker_int ${OpenMP_CXX_LIBRARIES})
 
-add_executable(scc app/signed_graph_clustering.cpp $<TARGET_OBJECTS:libclustering>)
-target_compile_definitions(scc PRIVATE "-DMODE_CLUSTERING")
-target_include_directories(scc PUBLIC ${MPI_CXX_INCLUDE_PATH})
-target_link_libraries(scc ${MPI_CXX_LIBRARIES} ${OpenMP_CXX_LIBRARIES} ${USE_TCMALLOC_LIBS})
-install(TARGETS scc DESTINATION bin)
+add_executable(scc_int app/signed_graph_clustering.cpp $<TARGET_OBJECTS:libclustering>)
+target_compile_definitions(scc_int PRIVATE "-DMODE_CLUSTERING")
+target_include_directories(scc_int PUBLIC ${MPI_CXX_INCLUDE_PATH})
+target_link_libraries(scc_int ${MPI_CXX_LIBRARIES} ${OpenMP_CXX_LIBRARIES} ${USE_TCMALLOC_LIBS})
 
-add_executable(scc_evolutionary app/signed_graph_clustering_evolutionary.cpp $<TARGET_OBJECTS:libclustering> $<TARGET_OBJECTS:libclustering_evolutionary>)
-target_compile_definitions(scc_evolutionary PRIVATE "-DMODE_CLUSTERING_EVOLUTIONARY")
-target_include_directories(scc_evolutionary PUBLIC ${MPI_CXX_INCLUDE_PATH})
-target_link_libraries(scc_evolutionary ${MPI_CXX_LIBRARIES} ${OpenMP_CXX_LIBRARIES} ${USE_TCMALLOC_LIBS})
-install(TARGETS scc_evolutionary DESTINATION bin)
+add_executable(scc_evolutionary_int app/signed_graph_clustering_evolutionary.cpp $<TARGET_OBJECTS:libclustering> $<TARGET_OBJECTS:libclustering_evolutionary>)
+target_compile_definitions(scc_evolutionary_int PRIVATE "-DMODE_CLUSTERING_EVOLUTIONARY")
+target_include_directories(scc_evolutionary_int PUBLIC ${MPI_CXX_INCLUDE_PATH})
+target_link_libraries(scc_evolutionary_int ${MPI_CXX_LIBRARIES} ${OpenMP_CXX_LIBRARIES} ${USE_TCMALLOC_LIBS})
+
+# ===================== Double executables =====================
+add_executable(scc_evaluator_double app/evaluator.cpp $<TARGET_OBJECTS:libkaffpa_double>)
+target_compile_definitions(scc_evaluator_double PRIVATE "-DMODE_EVALUATOR" "EDGE_WEIGHT_DOUBLE")
+target_link_libraries(scc_evaluator_double ${OpenMP_CXX_LIBRARIES})
+
+add_executable(scc_graphchecker_double app/graphchecker.cpp $<TARGET_OBJECTS:libkaffpa_double>)
+target_compile_definitions(scc_graphchecker_double PRIVATE "-DMODE_GRAPHCHECKER" "EDGE_WEIGHT_DOUBLE")
+target_link_libraries(scc_graphchecker_double ${OpenMP_CXX_LIBRARIES})
+
+add_executable(scc_double app/signed_graph_clustering.cpp $<TARGET_OBJECTS:libclustering_double>)
+target_compile_definitions(scc_double PRIVATE "-DMODE_CLUSTERING" "EDGE_WEIGHT_DOUBLE")
+target_include_directories(scc_double PUBLIC ${MPI_CXX_INCLUDE_PATH})
+target_link_libraries(scc_double ${MPI_CXX_LIBRARIES} ${OpenMP_CXX_LIBRARIES} ${USE_TCMALLOC_LIBS})
+
+add_executable(scc_evolutionary_double app/signed_graph_clustering_evolutionary.cpp $<TARGET_OBJECTS:libclustering_double> $<TARGET_OBJECTS:libclustering_evolutionary_double>)
+target_compile_definitions(scc_evolutionary_double PRIVATE "-DMODE_CLUSTERING_EVOLUTIONARY" "EDGE_WEIGHT_DOUBLE")
+target_include_directories(scc_evolutionary_double PUBLIC ${MPI_CXX_INCLUDE_PATH})
+target_link_libraries(scc_evolutionary_double ${MPI_CXX_LIBRARIES} ${OpenMP_CXX_LIBRARIES} ${USE_TCMALLOC_LIBS})
+
+# ===================== Auto-detecting launchers =====================
+add_executable(scc app/scc_launcher.cpp)
+add_executable(scc_evolutionary app/scc_evolutionary_launcher.cpp)
+add_executable(scc_evaluator app/evaluator_launcher.cpp)
+add_executable(scc_graphchecker app/graphchecker_launcher.cpp)
+
+install(TARGETS scc scc_int scc_double
+                scc_evolutionary scc_evolutionary_int scc_evolutionary_double
+                scc_evaluator scc_evaluator_int scc_evaluator_double
+                scc_graphchecker scc_graphchecker_int scc_graphchecker_double
+        DESTINATION bin)
 

--- a/app/evaluator_launcher.cpp
+++ b/app/evaluator_launcher.cpp
@@ -1,0 +1,95 @@
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <libgen.h>
+
+static bool file_has_double_weights(const std::string & filename) {
+        std::ifstream in(filename.c_str());
+        if (!in) return false;
+
+        std::string line;
+        std::getline(in, line);
+        while (!in.eof() && (line.empty() || line[0] == '%' || line[0] == '#')) {
+                std::getline(in, line);
+        }
+
+        std::stringstream hdr(line);
+        long nmbNodes, nmbEdges;
+        int ew = 0;
+        hdr >> nmbNodes >> nmbEdges >> ew;
+
+        bool has_edge_weights = (ew == 1 || ew == 11);
+        bool has_node_weights = (ew == 10 || ew == 11);
+
+        auto is_float_token = [](const std::string & tok) -> bool {
+                for (size_t i = 0; i < tok.size(); i++) {
+                        char c = tok[i];
+                        if (c == '.') return true;
+                        if ((c == 'e' || c == 'E') && i > 0) return true;
+                }
+                return false;
+        };
+
+        int lines_checked = 0;
+        while (lines_checked < 20 && std::getline(in, line)) {
+                if (line.empty() || line[0] == '%' || line[0] == '#') continue;
+                lines_checked++;
+
+                std::stringstream ss(line);
+                std::string tok;
+
+                if (ew == 0) {
+                        ss >> tok; ss >> tok;
+                        if (ss >> tok) {
+                                if (is_float_token(tok)) return true;
+                        }
+                } else {
+                        if (has_node_weights) ss >> tok;
+                        while (ss >> tok) {
+                                if (has_edge_weights && (ss >> tok)) {
+                                        if (is_float_token(tok)) return true;
+                                }
+                        }
+                }
+        }
+        return false;
+}
+
+static std::string find_graph_file(int argc, char** argv) {
+        for (int i = 1; i < argc; i++) {
+                if (argv[i][0] == '-') continue;
+                std::ifstream f(argv[i]);
+                if (f.good()) return argv[i];
+        }
+        return "";
+}
+
+int main(int argc, char** argv) {
+        std::string graph_file = find_graph_file(argc, argv);
+        if (graph_file.empty()) {
+                std::cerr << "Could not find graph file in arguments." << std::endl;
+                return 1;
+        }
+
+        char self_path[4096];
+        ssize_t len = readlink("/proc/self/exe", self_path, sizeof(self_path) - 1);
+        std::string dir;
+        if (len > 0) {
+                self_path[len] = '\0';
+                dir = std::string(dirname(self_path));
+        } else {
+                dir = ".";
+        }
+
+        bool use_double = file_has_double_weights(graph_file);
+        std::string target = dir + (use_double ? "/scc_evaluator_double" : "/scc_evaluator_int");
+
+        argv[0] = strdup(target.c_str());
+        execvp(target.c_str(), argv);
+
+        perror("execvp failed");
+        return 1;
+}

--- a/app/graphchecker_launcher.cpp
+++ b/app/graphchecker_launcher.cpp
@@ -1,0 +1,95 @@
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <libgen.h>
+
+static bool file_has_double_weights(const std::string & filename) {
+        std::ifstream in(filename.c_str());
+        if (!in) return false;
+
+        std::string line;
+        std::getline(in, line);
+        while (!in.eof() && (line.empty() || line[0] == '%' || line[0] == '#')) {
+                std::getline(in, line);
+        }
+
+        std::stringstream hdr(line);
+        long nmbNodes, nmbEdges;
+        int ew = 0;
+        hdr >> nmbNodes >> nmbEdges >> ew;
+
+        bool has_edge_weights = (ew == 1 || ew == 11);
+        bool has_node_weights = (ew == 10 || ew == 11);
+
+        auto is_float_token = [](const std::string & tok) -> bool {
+                for (size_t i = 0; i < tok.size(); i++) {
+                        char c = tok[i];
+                        if (c == '.') return true;
+                        if ((c == 'e' || c == 'E') && i > 0) return true;
+                }
+                return false;
+        };
+
+        int lines_checked = 0;
+        while (lines_checked < 20 && std::getline(in, line)) {
+                if (line.empty() || line[0] == '%' || line[0] == '#') continue;
+                lines_checked++;
+
+                std::stringstream ss(line);
+                std::string tok;
+
+                if (ew == 0) {
+                        ss >> tok; ss >> tok;
+                        if (ss >> tok) {
+                                if (is_float_token(tok)) return true;
+                        }
+                } else {
+                        if (has_node_weights) ss >> tok;
+                        while (ss >> tok) {
+                                if (has_edge_weights && (ss >> tok)) {
+                                        if (is_float_token(tok)) return true;
+                                }
+                        }
+                }
+        }
+        return false;
+}
+
+static std::string find_graph_file(int argc, char** argv) {
+        for (int i = 1; i < argc; i++) {
+                if (argv[i][0] == '-') continue;
+                std::ifstream f(argv[i]);
+                if (f.good()) return argv[i];
+        }
+        return "";
+}
+
+int main(int argc, char** argv) {
+        std::string graph_file = find_graph_file(argc, argv);
+        if (graph_file.empty()) {
+                std::cerr << "Could not find graph file in arguments." << std::endl;
+                return 1;
+        }
+
+        char self_path[4096];
+        ssize_t len = readlink("/proc/self/exe", self_path, sizeof(self_path) - 1);
+        std::string dir;
+        if (len > 0) {
+                self_path[len] = '\0';
+                dir = std::string(dirname(self_path));
+        } else {
+                dir = ".";
+        }
+
+        bool use_double = file_has_double_weights(graph_file);
+        std::string target = dir + (use_double ? "/scc_graphchecker_double" : "/scc_graphchecker_int");
+
+        argv[0] = strdup(target.c_str());
+        execvp(target.c_str(), argv);
+
+        perror("execvp failed");
+        return 1;
+}

--- a/app/scc_evolutionary_launcher.cpp
+++ b/app/scc_evolutionary_launcher.cpp
@@ -1,0 +1,95 @@
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <libgen.h>
+
+static bool file_has_double_weights(const std::string & filename) {
+        std::ifstream in(filename.c_str());
+        if (!in) return false;
+
+        std::string line;
+        std::getline(in, line);
+        while (!in.eof() && (line.empty() || line[0] == '%' || line[0] == '#')) {
+                std::getline(in, line);
+        }
+
+        std::stringstream hdr(line);
+        long nmbNodes, nmbEdges;
+        int ew = 0;
+        hdr >> nmbNodes >> nmbEdges >> ew;
+
+        bool has_edge_weights = (ew == 1 || ew == 11);
+        bool has_node_weights = (ew == 10 || ew == 11);
+
+        auto is_float_token = [](const std::string & tok) -> bool {
+                for (size_t i = 0; i < tok.size(); i++) {
+                        char c = tok[i];
+                        if (c == '.') return true;
+                        if ((c == 'e' || c == 'E') && i > 0) return true;
+                }
+                return false;
+        };
+
+        int lines_checked = 0;
+        while (lines_checked < 20 && std::getline(in, line)) {
+                if (line.empty() || line[0] == '%' || line[0] == '#') continue;
+                lines_checked++;
+
+                std::stringstream ss(line);
+                std::string tok;
+
+                if (ew == 0) {
+                        ss >> tok; ss >> tok;
+                        if (ss >> tok) {
+                                if (is_float_token(tok)) return true;
+                        }
+                } else {
+                        if (has_node_weights) ss >> tok;
+                        while (ss >> tok) {
+                                if (has_edge_weights && (ss >> tok)) {
+                                        if (is_float_token(tok)) return true;
+                                }
+                        }
+                }
+        }
+        return false;
+}
+
+static std::string find_graph_file(int argc, char** argv) {
+        for (int i = 1; i < argc; i++) {
+                if (argv[i][0] == '-') continue;
+                std::ifstream f(argv[i]);
+                if (f.good()) return argv[i];
+        }
+        return "";
+}
+
+int main(int argc, char** argv) {
+        std::string graph_file = find_graph_file(argc, argv);
+        if (graph_file.empty()) {
+                std::cerr << "Could not find graph file in arguments." << std::endl;
+                return 1;
+        }
+
+        char self_path[4096];
+        ssize_t len = readlink("/proc/self/exe", self_path, sizeof(self_path) - 1);
+        std::string dir;
+        if (len > 0) {
+                self_path[len] = '\0';
+                dir = std::string(dirname(self_path));
+        } else {
+                dir = ".";
+        }
+
+        bool use_double = file_has_double_weights(graph_file);
+        std::string target = dir + (use_double ? "/scc_evolutionary_double" : "/scc_evolutionary_int");
+
+        argv[0] = strdup(target.c_str());
+        execvp(target.c_str(), argv);
+
+        perror("execvp failed");
+        return 1;
+}

--- a/app/scc_launcher.cpp
+++ b/app/scc_launcher.cpp
@@ -1,0 +1,97 @@
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <libgen.h>
+
+static bool file_has_double_weights(const std::string & filename) {
+        std::ifstream in(filename.c_str());
+        if (!in) return false;
+
+        std::string line;
+        std::getline(in, line);
+        while (!in.eof() && (line.empty() || line[0] == '%' || line[0] == '#')) {
+                std::getline(in, line);
+        }
+
+        std::stringstream hdr(line);
+        long nmbNodes, nmbEdges;
+        int ew = 0;
+        hdr >> nmbNodes >> nmbEdges >> ew;
+
+        bool has_edge_weights = (ew == 1 || ew == 11);
+        bool has_node_weights = (ew == 10 || ew == 11);
+
+        auto is_float_token = [](const std::string & tok) -> bool {
+                for (size_t i = 0; i < tok.size(); i++) {
+                        char c = tok[i];
+                        if (c == '.') return true;
+                        if ((c == 'e' || c == 'E') && i > 0) return true;
+                }
+                return false;
+        };
+
+        int lines_checked = 0;
+        while (lines_checked < 20 && std::getline(in, line)) {
+                if (line.empty() || line[0] == '%' || line[0] == '#') continue;
+                lines_checked++;
+
+                std::stringstream ss(line);
+                std::string tok;
+
+                if (ew == 0) {
+                        ss >> tok; ss >> tok;
+                        if (ss >> tok) {
+                                if (is_float_token(tok)) return true;
+                        }
+                } else {
+                        if (has_node_weights) ss >> tok;
+                        while (ss >> tok) {
+                                if (has_edge_weights && (ss >> tok)) {
+                                        if (is_float_token(tok)) return true;
+                                }
+                        }
+                }
+        }
+        return false;
+}
+
+static std::string find_graph_file(int argc, char** argv) {
+        for (int i = 1; i < argc; i++) {
+                if (argv[i][0] == '-') continue;
+                std::ifstream f(argv[i]);
+                if (f.good()) return argv[i];
+        }
+        return "";
+}
+
+int main(int argc, char** argv) {
+        std::string graph_file = find_graph_file(argc, argv);
+        if (graph_file.empty()) {
+                std::cerr << "Could not find graph file in arguments." << std::endl;
+                return 1;
+        }
+
+        // resolve path to the directory containing this binary
+        char self_path[4096];
+        ssize_t len = readlink("/proc/self/exe", self_path, sizeof(self_path) - 1);
+        std::string dir;
+        if (len > 0) {
+                self_path[len] = '\0';
+                dir = std::string(dirname(self_path));
+        } else {
+                dir = ".";
+        }
+
+        bool use_double = file_has_double_weights(graph_file);
+        std::string target = dir + (use_double ? "/scc_double" : "/scc_int");
+
+        argv[0] = strdup(target.c_str());
+        execvp(target.c_str(), argv);
+
+        // execvp only returns on error
+        perror("execvp failed");
+        return 1;
+}

--- a/app/signed_graph_clustering.cpp
+++ b/app/signed_graph_clustering.cpp
@@ -3,9 +3,11 @@
 //
 
 #include <argtable3.h>
+#include <iomanip>
 #include <lib/clustering/signed_graph_clusterer.h>
 #include <tools/tools.h>
 #include <mpi.h>
+#include "tools/mpi_edge_weight.h"
 #include "parse_parameters.h"
 #include "partition/partition_config.h"
 #include "data_structure/graph_access.h"
@@ -21,6 +23,9 @@ void write_log(std::string & filename, std::stringstream& filebuffer_string);
 
 int main(int argn, char **argv) {
         MPI_Init(&argn, &argv);    /* starts MPI */
+#ifdef EDGE_WEIGHT_DOUBLE
+        std::cout << std::setprecision(17);
+#endif
         std::stringstream filebuffer_string;
 
         // Reading the graph
@@ -113,7 +118,7 @@ int main(int argn, char **argv) {
         quality_metrics qm;
 
         std::cout <<  "performing clustering!"  << std::endl;
-        EdgeWeight local_best_cut = std::numeric_limits<int>::max();
+        EdgeWeight local_best_cut = std::numeric_limits<EdgeWeight>::max();
         if(partition_config.time_limit == 0) {
                 signed_graph_clusterer clusterer;
                 clusterer.perform_signed_clustering(partition_config, G);
@@ -151,8 +156,8 @@ int main(int argn, char **argv) {
         }
         MPI_Barrier(communicator);
 
-        int overall_best_cut;
-        MPI_Reduce(&local_best_cut, &overall_best_cut, 1, MPI_INT, MPI_MIN, 0, MPI_COMM_WORLD);
+        EdgeWeight overall_best_cut;
+        MPI_Reduce(&local_best_cut, &overall_best_cut, 1, mpi_edge_weight_type(), MPI_MIN, 0, MPI_COMM_WORLD);
 
         int myrank = local_best_cut == overall_best_cut ? rank : 0;
         int minrank;

--- a/lib/algorithms/cycle_search.cpp
+++ b/lib/algorithms/cycle_search.cpp
@@ -6,6 +6,7 @@
  *****************************************************************************/
 
 #include <algorithm>
+#include <cmath>
 #include "algorithms/strongly_connected_components.h"
 #include "cycle_search.h"
 #include "random_functions.h"
@@ -152,7 +153,7 @@ bool cycle_search::find_shortest_path(graph_access & G,
                                       NodeID & dest, 
                                       std::vector<NodeID> & cycle) {
 
-        std::vector<EdgeWeight> distance(G.number_of_nodes(), std::numeric_limits<EdgeWeight>::max()/2);
+        std::vector<EdgeWeight> distance(G.number_of_nodes(), LARGE_EDGE_WEIGHT);
         std::vector<NodeID> parent(G.number_of_nodes(), std::numeric_limits<NodeID>::max());
 
         bool negative_cycle_detected = negative_cycle_detection(G, start, distance, parent, cycle);
@@ -174,7 +175,7 @@ bool cycle_search::find_shortest_path(graph_access & G,
 bool cycle_search::find_negative_cycle(graph_access & G, NodeID & start, std::vector<NodeID> & cycle) {
 	//simplest bellman ford algorithm
 
-	std::vector<EdgeWeight> distance(G.number_of_nodes(), std::numeric_limits<EdgeWeight>::max()/2);
+	std::vector<EdgeWeight> distance(G.number_of_nodes(), LARGE_EDGE_WEIGHT);
         std::vector<NodeID> parent(G.number_of_nodes(), std::numeric_limits<NodeID>::max());
 
         return negative_cycle_detection(G, start, distance, parent, cycle);
@@ -348,7 +349,7 @@ bool cycle_search::negative_cycle_detection(graph_access & G,
 //preconditition: no negative cycles 
 bool cycle_search::find_zero_weight_cycle(graph_access & G, NodeID & start, std::vector<NodeID> & cycle) {
 
-        std::vector<EdgeWeight> distance(G.number_of_nodes(), std::numeric_limits<EdgeWeight>::max()/2);
+        std::vector<EdgeWeight> distance(G.number_of_nodes(), LARGE_EDGE_WEIGHT);
 	std::vector<NodeID> parent(G.number_of_nodes(), std::numeric_limits<NodeID>::max());
         bool negative_weight_cycle = negative_cycle_detection(G, start, distance, parent, cycle);
         if(!negative_weight_cycle) {
@@ -365,7 +366,11 @@ bool cycle_search::find_zero_weight_cycle(graph_access & G, NodeID & start, std:
                                NodeID target                   = G.getEdgeTarget(e);
                                EdgeWeight modified_edge_weight = G.getEdgeWeight(e) + distance[node] - distance[target]; 
                                ASSERT_GEQ(modified_edge_weight, 0);
+#ifdef EDGE_WEIGHT_DOUBLE
+                               if(std::abs(modified_edge_weight) < 1e-9) {
+#else
                                if(modified_edge_weight == 0) {
+#endif
                                         EdgeID shadow_edge              = W.new_edge(shadow_node, target);
                                         W.setEdgeWeight(shadow_edge, 0);
                                }

--- a/lib/clustering/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_commons.h
+++ b/lib/clustering/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_commons.h
@@ -131,7 +131,7 @@ inline Gain kway_graph_refinement_commons::compute_gain(graph_access & G,
         //for all incident partitions compute gain
         //return max gain and max_gainer partition
         PartitionID source_partition = G.getPartitionIndex(node);
-        EdgeWeight max_degree        = std::numeric_limits<EdgeWeight>::min();
+        EdgeWeight max_degree        = std::numeric_limits<EdgeWeight>::lowest();
         max_gainer                   = INVALID_PARTITION;
 
         // Hoist edge array pointer for direct access (avoid graphref-> per edge)

--- a/lib/clustering/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.cpp
+++ b/lib/clustering/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.cpp
@@ -68,7 +68,7 @@ EdgeWeight kway_graph_refinement_core::single_kway_refinement_round_internal(Par
         int max_number_of_swaps = (int)(G.number_of_nodes());
         int min_cut_index       = -1;
 
-        EdgeWeight cut         = std::numeric_limits<EdgeWeight>::max()/2; // so we dont need to compute the edge cut
+        EdgeWeight cut         = LARGE_EDGE_WEIGHT; // so we dont need to compute the edge cut
         EdgeWeight initial_cut = cut;
 
         //roll forwards

--- a/lib/clustering/uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/two_way_fm.cpp
+++ b/lib/clustering/uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/two_way_fm.cpp
@@ -36,6 +36,9 @@ EdgeWeight two_way_fm::perform_refinement(PartitionConfig & cfg,
                                           bool & something_changed) {
 
         PartitionConfig config = cfg;  // copy it since we make changes on that
+#ifdef EDGE_WEIGHT_DOUBLE
+        config.use_bucket_queues = false;
+#endif
         if(lhs_start_nodes.size() == 0 or rhs_start_nodes.size() == 0) return 0; // nothing to refine
 
         quality_metrics qm;

--- a/lib/clustering_evolutionary/evolutionary_signed_graph_clusterer.cpp
+++ b/lib/clustering_evolutionary/evolutionary_signed_graph_clusterer.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <iostream>
 #include <mpi.h>
+#include "tools/mpi_edge_weight.h"
 #include "diversifyer.h"
 #include "exchange/exchanger.h"
 #include "graph_partitioner.h"
@@ -186,9 +187,9 @@ EdgeWeight evolutionary_signed_graph_clusterer::collect_best_clustering(graph_ac
 	EdgeWeight min_objective = 0;
 	m_island->apply_fittest(G, min_objective);
 
-	int best_local_objective  = min_objective;
-	int best_local_objective_m  = min_objective;
-	int best_global_objective = 0;
+	EdgeWeight best_local_objective  = min_objective;
+	EdgeWeight best_local_objective_m  = min_objective;
+	EdgeWeight best_global_objective = 0;
 
 	PartitionID* best_local_map = new PartitionID[G.number_of_nodes()];
 	std::vector< NodeWeight > block_sizes(G.get_partition_count(),0);
@@ -205,16 +206,16 @@ EdgeWeight evolutionary_signed_graph_clusterer::collect_best_clustering(graph_ac
 		}
 	}
 
-	MPI_Allreduce(&best_local_objective_m, &best_global_objective, 1, MPI_INT, MPI_MIN, m_communicator);
+	MPI_Allreduce(&best_local_objective_m, &best_global_objective, 1, mpi_edge_weight_type(), MPI_MIN, m_communicator);
 
-	if( best_global_objective == std::numeric_limits< int >::max()) {
+	if( best_global_objective == std::numeric_limits<EdgeWeight>::max()) {
 		//no partition is feasible
-		MPI_Allreduce(&best_local_objective, &best_global_objective, 1, MPI_INT, MPI_MIN, m_communicator);
+		MPI_Allreduce(&best_local_objective, &best_global_objective, 1, mpi_edge_weight_type(), MPI_MIN, m_communicator);
 	}
 
 	int my_domain_weight   = best_local_objective == best_global_objective ?
 		max_domain_weight : std::numeric_limits<int>::max();
-	int best_domain_weight = max_domain_weight;
+	int best_domain_weight = (int)max_domain_weight;
 
 	MPI_Allreduce(&my_domain_weight, &best_domain_weight, 1, MPI_INT, MPI_MIN, m_communicator);
 

--- a/lib/clustering_evolutionary/population.cpp
+++ b/lib/clustering_evolutionary/population.cpp
@@ -85,7 +85,7 @@ void population::insert(graph_access & G, Individuum & ind) {
         if(m_internal_population.size() < m_population_size) {
                 m_internal_population.push_back(ind);
         } else {
-                EdgeWeight worst_objective = std::numeric_limits<EdgeWeight>::min();
+                EdgeWeight worst_objective = std::numeric_limits<EdgeWeight>::lowest();
                 for( unsigned i = 0; i < m_internal_population.size(); i++) {
                         if(m_internal_population[i].objective > worst_objective) {
                                 worst_objective = m_internal_population[i].objective;

--- a/lib/data_structure/graph_access.h
+++ b/lib/data_structure/graph_access.h
@@ -423,7 +423,7 @@ inline EdgeWeight graph_access::getMaxDegree() {
                         forall_out_edges(ref, e, node) {
                                 cur_degree += getEdgeWeight(e);
                         } endfor
-                        if(abs(cur_degree) > m_max_degree) {
+                        if(std::abs(cur_degree) > m_max_degree) {
                                 m_max_degree = abs(cur_degree);
                         }
                 } endfor

--- a/lib/data_structure/priority_queues/maxNodeHeap.h
+++ b/lib/data_structure/priority_queues/maxNodeHeap.h
@@ -15,7 +15,7 @@
 
 #include "data_structure/priority_queues/priority_queue_interface.h"
 
-typedef int Key;
+typedef Gain Key;
 
 template < typename Data >
 class QElement {
@@ -105,13 +105,13 @@ inline NodeID maxNodeHeap::maxElement() {
 
 inline void maxNodeHeap::siftDown( int pos ) {
 
-        int curKey   = m_heap[pos].first;
+        Key curKey   = m_heap[pos].first;
         int lhsChild = 2*pos+1;
         int rhsChild = 2*pos+2;
         if( rhsChild < (int) m_heap.size() ) {
 
-                int lhsKey = m_heap[lhsChild].first;
-                int rhsKey = m_heap[rhsChild].first;
+                Key lhsKey = m_heap[lhsChild].first;
+                Key rhsKey = m_heap[rhsChild].first;
 
                 if( lhsKey < curKey && rhsKey < curKey) {
                         return; // we are done

--- a/lib/definitions.h
+++ b/lib/definitions.h
@@ -36,6 +36,11 @@ typedef uint64_t 		EdgeID;
 typedef int64_t 		EdgeWeight;
 typedef uint64_t 		NodeID;
 typedef uint64_t 		NodeWeight;
+#elif defined(EDGE_WEIGHT_DOUBLE)
+typedef unsigned int 		EdgeID;
+typedef double 			EdgeWeight;
+typedef unsigned int 		NodeID;
+typedef unsigned int 		NodeWeight;
 #else
 typedef unsigned int 		EdgeID;
 typedef int 			EdgeWeight;
@@ -48,7 +53,12 @@ typedef unsigned int 		Count;
 typedef std::vector<NodeID> boundary_starting_nodes;
 typedef long FlowType;
 
-const EdgeWeight MIN_EDGE_WEIGHT       = std::numeric_limits<EdgeWeight>::min();
+const EdgeWeight MIN_EDGE_WEIGHT       = std::numeric_limits<EdgeWeight>::lowest();
+#ifdef EDGE_WEIGHT_DOUBLE
+const EdgeWeight LARGE_EDGE_WEIGHT     = 1e15; // sentinel for FM refinement (DBL_MAX/2 loses precision)
+#else
+const EdgeWeight LARGE_EDGE_WEIGHT     = std::numeric_limits<EdgeWeight>::max()/2;
+#endif
 const EdgeID UNDEFINED_EDGE            = std::numeric_limits<EdgeID>::max();
 const NodeID UNDEFINED_NODE            = std::numeric_limits<NodeID>::max();
 const NodeID UNASSIGNED                = std::numeric_limits<NodeID>::max();

--- a/lib/io/graph_io.cpp
+++ b/lib/io/graph_io.cpp
@@ -5,6 +5,8 @@
  * Christian Schulz <christian.schulz.phone@gmail.com>
  *****************************************************************************/
 
+#include <cmath>
+#include <iomanip>
 #include <sstream>
 #include <map>
 #include <unordered_map>
@@ -205,20 +207,25 @@ int graph_io::readWeightedEdgeStreamToGraph(graph_access & G, const std::string 
 		}	
 
 		// Substitute arcs and parallel edges by a single undirected edge whose weight equals the sum of arc weights
-		if (neighbors[real_x].find(real_y) == neighbors[real_x].end() || neighbors[real_x][real_y] == 0) {
+#ifdef EDGE_WEIGHT_DOUBLE
+		auto is_zero = [](EdgeWeight w) { return std::abs(w) < 1e-9; };
+#else
+		auto is_zero = [](EdgeWeight w) { return w == 0; };
+#endif
+		if (neighbors[real_x].find(real_y) == neighbors[real_x].end() || is_zero(neighbors[real_x][real_y])) {
 			neighbors[real_x][real_y] = ew;
 			num_edges++;
 		} else {
 			neighbors[real_x][real_y] += ew;
-			if (neighbors[real_x][real_y] == 0) num_edges--;
+			if (is_zero(neighbors[real_x][real_y])) num_edges--;
 		}
 
-		if (neighbors[real_y].find(real_x) == neighbors[real_y].end() || neighbors[real_y][real_x] == 0) {
+		if (neighbors[real_y].find(real_x) == neighbors[real_y].end() || is_zero(neighbors[real_y][real_x])) {
 			neighbors[real_y][real_x] = ew;
 			num_edges++;
 		} else {
 			neighbors[real_y][real_x] += ew;
-			if (neighbors[real_y][real_x] == 0) num_edges--;
+			if (is_zero(neighbors[real_y][real_x])) num_edges--;
 		}
 	}
 
@@ -237,7 +244,11 @@ int graph_io::readWeightedEdgeStreamToGraph(graph_access & G, const std::string 
 		for (auto& it : neighbors[node]) {
 			NodeID target = it.first;
                         EdgeWeight edge_weight = it.second;
+#ifdef EDGE_WEIGHT_DOUBLE
+			if (std::abs(edge_weight) < 1e-9) continue;
+#else
 			if (edge_weight == 0) continue;
+#endif
                         EdgeID e = G.new_edge(node, target);
                         G.setEdgeWeight(e, edge_weight);
                 }
@@ -263,6 +274,9 @@ int graph_io::writeGraph(graph_access & G, const std::string & filename) {
 
 int graph_io::writeGraphWeighted(graph_access & G, const std::string & filename) {
         std::ofstream f(filename.c_str());
+#ifdef EDGE_WEIGHT_DOUBLE
+        f << std::setprecision(17);
+#endif
         f << G.number_of_nodes() <<  " " <<  G.number_of_edges()/2 <<  " 11" <<  std::endl;
 
         forall_nodes(G, node) {
@@ -376,8 +390,72 @@ void graph_io::writeLogFile(LogVector & output_log, const std::string & filename
 
 	for (int pos=0; pos<output_log.size(); pos++) {
                 f << output_log.timestamp(pos) << " " << output_log.objective(pos) <<  "\n";
-        } 
+        }
 
         f.close();
+}
+
+bool graph_io::file_has_double_weights(const std::string & filename) {
+        std::ifstream in(filename.c_str());
+        if (!in) return false;
+
+        std::string line;
+
+        // skip comment lines
+        std::getline(in, line);
+        while (!in.eof() && (line.empty() || line[0] == '%' || line[0] == '#')) {
+                std::getline(in, line);
+        }
+
+        // parse header: nodes edges [format]
+        std::stringstream hdr(line);
+        long nmbNodes, nmbEdges;
+        int ew = 0;
+        hdr >> nmbNodes >> nmbEdges >> ew;
+
+        bool has_edge_weights = (ew == 1 || ew == 11);
+        bool has_node_weights = (ew == 10 || ew == 11);
+
+        // helper: check if a string token looks like a floating-point number
+        auto is_float_token = [](const std::string & tok) -> bool {
+                for (size_t i = 0; i < tok.size(); i++) {
+                        char c = tok[i];
+                        if (c == '.') return true;
+                        if ((c == 'e' || c == 'E') && i > 0) return true;
+                }
+                return false;
+        };
+
+        // scan up to 20 data lines
+        int lines_checked = 0;
+        while (lines_checked < 20 && std::getline(in, line)) {
+                if (line.empty() || line[0] == '%' || line[0] == '#') continue;
+                lines_checked++;
+
+                std::stringstream ss(line);
+                std::string tok;
+
+                if (ew == 0) {
+                        // edge stream format: src dst weight
+                        // first two tokens are node IDs, third is weight
+                        ss >> tok; // src
+                        ss >> tok; // dst
+                        if (ss >> tok) {
+                                if (is_float_token(tok)) return true;
+                        }
+                } else {
+                        // METIS format: [nodeweight] target weight target weight ...
+                        if (has_node_weights) {
+                                ss >> tok; // skip node weight
+                        }
+                        while (ss >> tok) { // target
+                                if (has_edge_weights && (ss >> tok)) {
+                                        if (is_float_token(tok)) return true;
+                                }
+                        }
+                }
+        }
+
+        return false;
 }
 

--- a/lib/io/graph_io.h
+++ b/lib/io/graph_io.h
@@ -114,6 +114,9 @@ class graph_io {
 		static
 		void writeLogFile(LogVector & output_log, const std::string & filename);
 		///////// Methods for processing logs
+
+                static
+                bool file_has_double_weights(const std::string & filename);
 };
 
 template<typename vectortype>

--- a/lib/partition/uncoarsening/refinement/cycle_improvements/augmented_Qgraph_fabric.cpp
+++ b/lib/partition/uncoarsening/refinement/cycle_improvements/augmented_Qgraph_fabric.cpp
@@ -10,6 +10,7 @@
 #include "algorithms/cycle_search.h"
 #include "augmented_Qgraph_fabric.h"
 #include "data_structure/priority_queues/bucket_pq.h"
+#include "data_structure/priority_queues/maxNodeHeap.h"
 #include "partition_snapshooter.h"
 #include "quality_metrics.h"
 #include "random_functions.h"
@@ -293,8 +294,12 @@ void augmented_Qgraph_fabric::directed_more_locallized_search(PartitionConfig & 
                                                    NodeID start_node, unsigned & number_of_swaps, pairwise_local_search & pls) {
 
         //commons = kway_graph_refinement_commons::getInstance(config);
+#ifdef EDGE_WEIGHT_DOUBLE
+        refinement_pq* queue  = new maxNodeHeap();
+#else
         EdgeWeight max_degree = G.getMaxDegree();
         refinement_pq* queue  = new bucket_pq(max_degree);
+#endif
 
         EdgeWeight int_degree = 0;
         EdgeWeight ext_degree = 0;
@@ -373,9 +378,14 @@ void augmented_Qgraph_fabric::more_locallized_search(PartitionConfig & config, g
         //commons = kway_graph_refinement_commons::getInstance(config);
         refinement_pq* queue_lhs = NULL;
         refinement_pq* queue_rhs = NULL;
+#ifdef EDGE_WEIGHT_DOUBLE
+        queue_lhs = new maxNodeHeap();
+        queue_rhs = new maxNodeHeap();
+#else
         EdgeWeight max_degree = G.getMaxDegree();
         queue_lhs = new bucket_pq(max_degree);
         queue_rhs = new bucket_pq(max_degree);
+#endif
 
         EdgeWeight int_degree = 0;
         EdgeWeight ext_degree = 0;

--- a/lib/partition/uncoarsening/refinement/cycle_improvements/greedy_neg_cycle.h
+++ b/lib/partition/uncoarsening/refinement/cycle_improvements/greedy_neg_cycle.h
@@ -178,8 +178,8 @@ inline void greedy_neg_cycle::init_gains_new( PartitionConfig & partition_config
         forall_nodes(G_bar, block) {
                 forall_out_edges(G_bar, e, block) {
                         NodeID target_block = G_bar.getEdgeTarget(e);
-                        EdgeWeight max_gain = std::numeric_limits<EdgeWeight>::min()/100;
-              
+                        EdgeWeight max_gain = std::numeric_limits<EdgeWeight>::lowest()/100;
+
                         PartialBoundary & lhs_b = boundary.getDirectedBoundary(block, block, target_block);
                         
                         std::vector<NodeID> lhs_boundary;
@@ -242,7 +242,7 @@ inline void greedy_neg_cycle::init_gains( PartitionConfig & partition_config,
         forall_nodes(G_bar, block) {
                 forall_out_edges(G_bar, e, block) {
                         NodeID target_block = G_bar.getEdgeTarget(e);
-                        EdgeWeight max_gain = std::numeric_limits<EdgeWeight>::min()/100;
+                        EdgeWeight max_gain = std::numeric_limits<EdgeWeight>::lowest()/100;
 
                         forall_nodes(G, node) {
                                 bool valid = true;

--- a/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.cpp
+++ b/lib/partition/uncoarsening/refinement/kway_graph_refinement/kway_graph_refinement_core.cpp
@@ -56,11 +56,14 @@ EdgeWeight kway_graph_refinement_core::single_kway_refinement_round_internal(Par
         if( commons == NULL ) commons = new kway_graph_refinement_commons(config);
 
         refinement_pq* queue = NULL;
+#ifndef EDGE_WEIGHT_DOUBLE
         if(config.use_bucket_queues) {
                 EdgeWeight max_degree = G.getMaxDegree();
                 queue                 = new bucket_pq(max_degree);
-        } else {
-                queue                 = new maxNodeHeap(); 
+        } else
+#endif
+        {
+                queue                 = new maxNodeHeap();
         }
 
         init_queue_with_boundary(config, G, start_nodes, queue, moved_idx);  
@@ -74,7 +77,7 @@ EdgeWeight kway_graph_refinement_core::single_kway_refinement_round_internal(Par
         int max_number_of_swaps = (int)(G.number_of_nodes());
         int min_cut_index       = -1;
 
-        EdgeWeight cut         = std::numeric_limits<int>::max()/2; // so we dont need to compute the edge cut
+        EdgeWeight cut         = LARGE_EDGE_WEIGHT; // so we dont need to compute the edge cut
         EdgeWeight initial_cut = cut;
 
         //roll forwards

--- a/lib/partition/uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/two_way_fm.cpp
+++ b/lib/partition/uncoarsening/refinement/quotient_graph_refinement/2way_fm_refinement/two_way_fm.cpp
@@ -36,6 +36,9 @@ EdgeWeight two_way_fm::perform_refinement(PartitionConfig & cfg,
                                           bool & something_changed) {
 
         PartitionConfig config = cfg; //copy it since we make changes on that
+#ifdef EDGE_WEIGHT_DOUBLE
+        config.use_bucket_queues = false;
+#endif
         if(lhs_start_nodes.size() == 0 or rhs_start_nodes.size() == 0) return 0; // nothing to refine
 
         quality_metrics qm;

--- a/lib/tools/mpi_edge_weight.h
+++ b/lib/tools/mpi_edge_weight.h
@@ -1,0 +1,17 @@
+#ifndef MPI_EDGE_WEIGHT_H
+#define MPI_EDGE_WEIGHT_H
+
+#include <mpi.h>
+#include "definitions.h"
+
+inline MPI_Datatype mpi_edge_weight_type() {
+#if defined(EDGE_WEIGHT_DOUBLE)
+        return MPI_DOUBLE;
+#elif defined(MODE64BITEDGES)
+        return MPI_LONG_LONG_INT;
+#else
+        return MPI_INT;
+#endif
+}
+
+#endif


### PR DESCRIPTION
## Summary

- Add support for `double` edge weights alongside the existing `int` path via a compile-time `EDGE_WEIGHT_DOUBLE` preprocessor flag
- CMake builds both int and double variants of every executable (`scc_int`/`scc_double`, etc.)
- Thin auto-detecting launcher binaries (`scc`, `scc_evolutionary`, `scc_evaluator`, `scc_graphchecker`) inspect the input file for floating-point tokens and `execvp` the correct variant
- The int code path is **completely unchanged** — verified bit-exact on 20 instances × 5 seeds (100/100 identical partition outputs vs. the pre-change binary)

## Changes

**Core type system** (`lib/definitions.h`):
- `EDGE_WEIGHT_DOUBLE` typedef guard (`EdgeWeight = double` when defined)
- `LARGE_EDGE_WEIGHT` sentinel constant — fixes a precision bug where `DBL_MAX/2` caused FM refinement to see zero improvement (ULP ≈ 1e291)
- `min()` → `lowest()` (no-op for int, critical for double)

**I/O** (`lib/io/graph_io.{h,cpp}`):
- `file_has_double_weights()` — scans file header + first 20 data lines for `.`/`e`/`E` in weight tokens
- Epsilon comparisons for `== 0` edge cancellation checks in `readWeightedEdgeStreamToGraph`
- Full precision (`setprecision(17)`) output for double weights

**Priority queues** (`maxNodeHeap.h`, `bucket_pq` guards):
- `typedef int Key` → `typedef Gain Key` so heap comparisons work with double gains
- `bucket_pq` (gain-as-array-index) disabled under `EDGE_WEIGHT_DOUBLE`; falls back to `maxNodeHeap`

**MPI** (`lib/tools/mpi_edge_weight.h`):
- `mpi_edge_weight_type()` helper returns `MPI_DOUBLE`/`MPI_INT`/`MPI_LONG_LONG_INT`
- Fixed hardcoded `int` variables holding `EdgeWeight` objectives in MPI reduce calls

**Build system** (`CMakeLists.txt`):
- C++17 (for `if constexpr` support in future)
- Dual object libraries: `libclustering`/`libclustering_double`, `libkaffpa`/`libkaffpa_double`, etc.
- 12 executable targets: 4 launchers + 4 int + 4 double

## Test plan

- [x] Bit-exact: 20 instances × 5 seeds, old `scc` vs new `scc_int` → 100/100 identical partitions
- [x] Double quality: `scc_int` on int graphs vs `scc_double` on double-converted graphs → geomean ratio 1.0 (0% deviation)
- [x] Auto-detection: launcher correctly dispatches to `scc_int` for integer files and `scc_double` for floating-point files
- [x] All 12 targets build cleanly (no warnings in new code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)